### PR TITLE
switch from Tets::CChecker (deprecated) to Test::Alien

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -40,7 +40,6 @@ my %module_build_args = (
   configure_requires  => {
     "perl"               => '5.010001',
     "Alien::Base"        => '0.020',
-    "ExtUtils::CChecker" => '0.10',
     "File::ShareDir"     => '1.03',
     "Module::Build"      => '0.42',
     "PkgConfig"          => '0.14026',
@@ -62,12 +61,12 @@ my %module_build_args = (
     "perl"           => '5.010001'
   },
   test_requires =>
-    {"Test::CChecker" => 0, "Test::More" => '0.94', "perl" => '5.010001'},
+    {"Test::Alien" => '0.16', "Test::More" => '0.94', "perl" => '5.010001'},
 
 );
 
 my %fallback_build_requires
-  = ("Test::CChecker" => 0, "Test::More" => '0.94', "perl" => '5.010001');
+  = ("Test::Alien" => '0.16', "Test::More" => '0.94', "perl" => '5.010001');
 
 unless (eval { Module::Build->VERSION(0.4004) }) {
   delete $module_build_args{test_requires};

--- a/META.json
+++ b/META.json
@@ -23,7 +23,6 @@
       "configure" : {
          "requires" : {
             "Alien::Base" : "0.020",
-            "ExtUtils::CChecker" : "0.10",
             "File::ShareDir" : "1.03",
             "Module::Build" : "0.42",
             "PkgConfig" : "0.14026",
@@ -41,7 +40,7 @@
       },
       "test" : {
          "requires" : {
-            "Test::CChecker" : "0",
+            "Test::Alien" : "0.16",
             "Test::More" : "0.94",
             "perl" : "5.010001"
          }
@@ -60,5 +59,5 @@
       ]
    },
    "version" : "2.000000",
-   "x_serialization_backend" : "JSON::PP version 2.97001"
+   "x_serialization_backend" : "JSON::PP version 4.00"
 }

--- a/META.yml
+++ b/META.yml
@@ -5,12 +5,11 @@ author:
 build_requires:
   IO::Socket::SSL: '1.56'
   Net::SSLeay: '1.49'
-  Test::CChecker: '0'
+  Test::Alien: '0.16'
   Test::More: '0.94'
   perl: '5.010001'
 configure_requires:
   Alien::Base: '0.020'
-  ExtUtils::CChecker: '0.10'
   File::ShareDir: '1.03'
   Module::Build: '0.42'
   PkgConfig: '0.14026'

--- a/t/00_diag.txt
+++ b/t/00_diag.txt
@@ -1,6 +1,5 @@
 Alien::Base
-ExtUtils::CChecker
 File::ShareDir
-Test::CChecker
 Test::More
+Test::Alien
 parent

--- a/t/02_compile.t
+++ b/t/02_compile.t
@@ -1,26 +1,28 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::CChecker;
+use Test::Alien;
 use Alien::SNMP;
 
-plan tests => 1;
+alien_ok 'Alien::SNMP';
 
-compile_output_to_note;
-
-compile_with_alien 'Alien::SNMP';
-
-compile_run_ok <<'C_CODE', "basic compile test";
+xs_ok <<'XS_CODE'
+#include "EXTERN.h"
+#include "perl.h"
+#include "XSUB.h"
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/version.h>
 
-int
-main(int argc, char *argv[])
-{
-  const char *version;
-  version = netsnmp_get_version();
-  return 0;
-}
-C_CODE
+MODULE = SNMP PACKAGE = SNMP
 
-1;
+const char *
+netsnmp_get_version()
+
+XS_CODE
+, with_subtest {
+  my $version;
+  ok $version = SNMP::netsnmp_get_version();
+  note "version = $version";
+};
+
+done_testing;


### PR DESCRIPTION
`Test::CChecker` is deprecated.  `Test::Alien` is in my opinion (the author of both) much better for testing Aliens (the latter tests by building an executable, the former builds a toy XS which can be tested in much the same way as a real XS will be used).  Also Test::Alien comes bundled along with `Alien::Base` in `Alien-Build`.  So this will reduce your dependencies.