### PR TITLE
Fix prereqs. AB is needed at runtime. ABMB is needed at configure.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -37,12 +37,12 @@ my %module_build_args = (
   },
   alien_stage_install => 0,
   build_requires      => {
-    'Alien::Base::ModuleBuild' => '0',
+    "Alien::Base"        => '0.020',
     'Software::License' => '0',
   },
   configure_requires  => {
     "perl"               => '5.010001',
-    "Alien::Base"        => '0.020',
+    'Alien::Base::ModuleBuild' => '0',
     "File::ShareDir"     => '1.03',
     "Module::Build"      => '0.42',
     "PkgConfig"          => '0.14026',

--- a/META.json
+++ b/META.json
@@ -16,7 +16,7 @@
    "prereqs" : {
       "build" : {
          "requires" : {
-            "Alien::Base::ModuleBuild" : "0",
+            "Alien::Base" : "0.020",
             "IO::Socket::SSL" : "1.56",
             "Net::SSLeay" : "1.49",
             "Software::License" : "0"
@@ -24,7 +24,7 @@
       },
       "configure" : {
          "requires" : {
-            "Alien::Base" : "0.020",
+            "Alien::Base::ModuleBuild" : "0",
             "File::ShareDir" : "1.03",
             "Module::Build" : "0.42",
             "PkgConfig" : "0.14026",

--- a/META.yml
+++ b/META.yml
@@ -3,7 +3,7 @@ abstract: 'Build and install Net-SNMP'
 author:
   - 'Eric A. Miller <emiller AT cpan DOT org>'
 build_requires:
-  Alien::Base::ModuleBuild: '0'
+  Alien::Base: '0.020'
   IO::Socket::SSL: '1.56'
   Net::SSLeay: '1.49'
   Software::License: '0'
@@ -11,7 +11,7 @@ build_requires:
   Test::More: '0.94'
   perl: '5.010001'
 configure_requires:
-  Alien::Base: '0.020'
+  Alien::Base::ModuleBuild: '0'
   File::ShareDir: '1.03'
   Module::Build: '0.42'
   PkgConfig: '0.14026'


### PR DESCRIPTION
Hello :smile: 

First thank you a lot for this alien module.

I propose this change to fix this [RT issue](https://rt.cpan.org/Public/Dist/Display.html?Name=Alien-SNMP) and also this [failed build](https://github.com/thibaultduponchelle/aliens-ci/runs/631550141?check_suite_focus=true)

Actually AB is needed at runtime and ABMB at configure (this latter is what is important to fix).

/cc @plicease 

Best regards.

Thibault

