### PR TITLE
Install or tests will fail

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -20,7 +20,7 @@ my $conf_cmd = [
 my %module_build_args = (
   alien_autoconf_with_pic => 0,
   alien_build_commands =>
-    ["%x -I../../inc -MMy::AlienPatch -e alien_patch", $conf_cmd, 'make'],
+    ["%x -I../../inc -MMy::AlienPatch -e alien_patch", $conf_cmd, 'make', 'make install'],
 
   # Not using FFI, default_store library only dynamic and needed for XS
   alien_isolate_dynamic => 0,
@@ -64,7 +64,11 @@ my %module_build_args = (
     "perl"           => '5.010001'
   },
   test_requires =>
-    {"Test::Alien" => '0.16', "Test::More" => '0.94', "perl" => '5.010001'},
+  {
+    "Test::Alien" => '0.16',
+    "Test::More" => '0.94',
+    "perl" => '5.010001'
+  },
 
   meta_merge => {
     resources  => {

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Eric A. Miller <emiller AT cpan DOT org>"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "Module::Build version 0.4224",
+   "generated_by" : "Module::Build version 0.4231",
    "license" : [
       "bsd"
    ],
@@ -64,5 +64,5 @@
       }
    },
    "version" : "2.002000",
-   "x_serialization_backend" : "JSON::PP version 2.97001"
+   "x_serialization_backend" : "JSON::PP version 4.04"
 }

--- a/META.yml
+++ b/META.yml
@@ -18,7 +18,7 @@ configure_requires:
   Test2::Suite: '0.000067'
   perl: '5.010001'
 dynamic_config: 1
-generated_by: 'Module::Build version 0.4224, CPAN::Meta::Converter version 2.150010'
+generated_by: 'Module::Build version 0.4231, CPAN::Meta::Converter version 2.150010'
 license: bsd
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html


### PR DESCRIPTION
Hello,

When I enabled the tests for this module, I got an error for the `use_ok "SNMP"` see this [failed build](https://github.com/thibaultduponchelle/aliens-ci/runs/709201988?check_suite_focus=true) for instance.

I propose this change to really install Perl modules .pm files.

The code in this PR is tested and [build is green](https://github.com/thibaultduponchelle/messy-perl-ci-workflows/runs/709548011?check_suite_focus=true).

I hope it will be OK for you :smile: 

Best regards.

//cc @plicease 

Thibault