### PR TITLE
Stage install so Test::Alien can link against built libnetsnmp

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -40,7 +40,9 @@ my %module_build_args = (
     location       => '/netdisco/upstream-sources/blob/master/net-snmp/',
     exact_filename => 'net-snmp-5.9.4.tar.gz?raw=true',
   },
-  alien_stage_install => 0,
+  # Stage into a unified lib/ before the test phase so Test::Alien can link
+  # against the built libnetsnmp (libtool keeps it in */.libs until installed)
+  alien_stage_install => 1,
   build_requires      => {
     "Alien::Base"        => '0.020',
     'Software::License' => '0',


### PR DESCRIPTION
This resolves an issue that required me to run cpanm with the --force or --notest flag.

With alien_stage_install => 0, the test phase ran before the library was copied into a unified lib/ directory; libtool keeps the built .so/.a files in */.libs until install, so t/02_compile.t failed to link with "cannot find -lnetsnmp" on modern perl/Alien::Base toolchains.
